### PR TITLE
Add before and after scenario and step hook messages

### DIFF
--- a/_testdata/sample.json
+++ b/_testdata/sample.json
@@ -35,7 +35,9 @@
                             ],
                             "table": null,
                             "beforeStepHookFailure": null,
+                            "beforeStepHookMessages": [],
                             "afterStepHookFailure": null,
+                            "afterStepHookMessages": [],
                             "result": {
                                 "status": "pass",
                                 "stackTrace": "",
@@ -69,7 +71,9 @@
                             ],
                             "table": null,
                             "beforeStepHookFailure": null,
+                            "beforeStepHookMessages": [],
                             "afterStepHookFailure": null,
+                            "afterStepHookMessages": [],
                             "result": {
                                 "status": "pass",
                                 "stackTrace": "",
@@ -83,7 +87,9 @@
                         }
                     ],
                     "beforeScenarioHookFailure": null,
+                    "beforeScenarioHookMessages": [],
                     "afterScenarioHookFailure": null,
+                    "afterScenarioHookMessages": [],
                     "skipErrors": [],
                     "tableRowIndex": -1
                 },
@@ -106,7 +112,9 @@
                             ],
                             "table": null,
                             "beforeStepHookFailure": null,
+                            "beforeStepHookMessages": [],
                             "afterStepHookFailure": null,
+                            "afterStepHookMessages": [],
                             "result": {
                                 "status": "pass",
                                 "stackTrace": "",
@@ -208,7 +216,9 @@
                                 ]
                             },
                             "beforeStepHookFailure": null,
+                            "beforeStepHookMessages": [],
                             "afterStepHookFailure": null,
+                            "afterStepHookMessages": [],
                             "result": {
                                 "status": "pass",
                                 "stackTrace": "",
@@ -222,7 +232,9 @@
                         }
                     ],
                     "beforeScenarioHookFailure": null,
+                    "beforeScenarioHookMessages": [],
                     "afterScenarioHookFailure": null,
+                    "afterScenarioHookMessages": [],
                     "skipErrors": [],
                     "tableRowIndex": -1
                 }
@@ -230,14 +242,18 @@
             "isTableDriven": false,
             "datatable": null,
             "beforeSpecHookFailure": null,
+            "beforeSpecHookMessages": [],
             "afterSpecHookFailure": null,
+            "afterSpecHookMessages": [],
             "passedScenarioCount": 2,
             "failedScenarioCount": 0,
             "skippedScenarioCount": 0
         }
     ],
     "beforeSuiteHookFailure": null,
+    "beforeSuiteHookMessages": [],
     "afterSuiteHookFailure": null,
+    "afterSuiteHookMessages": [],
     "passedSpecsCount": 1,
     "failedSpecsCount": 0,
     "skippedSpecsCount": 0,

--- a/schema.json
+++ b/schema.json
@@ -42,9 +42,23 @@
             "description": "Before suite hook failure information",
             "$ref": "#/definitions/hookFailure"
         },
+        "beforeSuiteHookMessages": {
+            "description": "Custom messages written in before suite hooks",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
         "afterSuiteHookFailure": {
             "description": "After suite hook failure information",
             "$ref": "#/definitions/hookFailure"
+        },
+        "afterSuiteHookMessages": {
+            "description": "Custom messages written in after suite hooks",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         },
         "passedSpecsCount": {
             "description": "Number of passed specifications",
@@ -81,7 +95,9 @@
         "executionStatus",
         "specResults",
         "beforeSuiteHookFailure",
+        "beforeSuiteHookMessages",
         "afterSuiteHookFailure",
+        "afterSuiteHookMessages",
         "passedSpecsCount",
         "failedSpecsCount",
         "skippedSpecsCount",
@@ -230,9 +246,23 @@
                     "description": "Before spec hook failure information",
                     "$ref": "#/definitions/hookFailure"
                 },
+                "beforeSpecHookMessages": {
+                    "description": "Custom messages written in before spec hooks",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "afterSpecHookFailure": {
                     "description": "After spec hook failure information",
                     "$ref": "#/definitions/hookFailure"
+                },
+                "afterSpecHookMessages": {
+                    "description": "Custom messages written in after spec hooks",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "passedScenarioCount": {
                     "description": "Number of passed scenarios in specification",
@@ -257,7 +287,9 @@
                 "isTableDriven",
                 "datatable",
                 "beforeSpecHookFailure",
+                "beforeSpecHookMessages",
                 "afterSpecHookFailure",
+                "afterSpecHookMessages",
                 "passedScenarioCount",
                 "failedScenarioCount",
                 "skippedScenarioCount"

--- a/schema.json
+++ b/schema.json
@@ -171,9 +171,23 @@
                                 "description": "Before scenario hook failure",
                                 "$ref": "#/definitions/hookFailure"
                             },
+                            "beforeScenarioHookMessages": {
+                                "description": "Custom messages written in before scenario hooks",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
                             "afterScenarioHookFailure": {
                                 "description": "After scenario hook failure",
                                 "$ref": "#/definitions/hookFailure"
+                            },
+                            "afterScenarioHookMessages": {
+                                "description": "Custom messages written in after scenario hooks",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             },
                             "skipErrors": {
                                 "description": "Reasons if scenario is skipped",
@@ -196,7 +210,9 @@
                             "teardowns",
                             "items",
                             "beforeScenarioHookFailure",
+                            "beforeScenarioHookMessages",
                             "afterScenarioHookFailure",
+                            "afterScenarioHookMessages",
                             "skipErrors",
                             "tableRowIndex"
                         ]
@@ -345,9 +361,23 @@
                     "description": "Before step hook failure information",
                     "$ref": "#/definitions/hookFailure"
                 },
+                "beforeStepHookMessages": {
+                    "description": "Custom messages written in before step hooks",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "afterStepHookFailure": {
                     "description": "After step hook failure information",
                     "$ref": "#/definitions/hookFailure"
+                },
+                "afterStepHookMessages": {
+                    "description": "Custom messages written in after step hooks",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "result": {
                     "description": "Execution result",
@@ -358,7 +388,9 @@
                 "itemType",
                 "stepText",
                 "beforeStepHookFailure",
+                "beforeStepHookMessages",
                 "afterStepHookFailure",
+                "afterStepHookMessages",
                 "result",
                 "parameters"
             ]


### PR DESCRIPTION
Solution as described in https://github.com/getgauge-contrib/json-report/issues/18. Adds pre and post hook messages to scenarios and steps.