### PR TITLE
Add arm64 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Setup go 1.13.1
-        uses: actions/setup-go@v1
+      - name: Setup go 1.17
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.13.1
+          go-version: 1.17.5
 
       - name: Run tests
         run: |

--- a/build/make.go
+++ b/build/make.go
@@ -25,6 +25,7 @@ const (
 	GOARCH            = "GOARCH"
 	GOOS              = "GOOS"
 	X86               = "386"
+	ARM64            = "arm64"
 	X86_64            = "amd64"
 	DARWIN            = "darwin"
 	LINUX             = "linux"
@@ -289,12 +290,13 @@ var binDir = flag.String("bin-dir", "", "Specifies OS_PLATFORM specific binaries
 
 var (
 	platformEnvs = []map[string]string{
-		map[string]string{GOARCH: X86, GOOS: DARWIN, CGO_ENABLED: "0"},
-		map[string]string{GOARCH: X86_64, GOOS: DARWIN, CGO_ENABLED: "0"},
-		map[string]string{GOARCH: X86, GOOS: LINUX, CGO_ENABLED: "0"},
-		map[string]string{GOARCH: X86_64, GOOS: LINUX, CGO_ENABLED: "0"},
-		map[string]string{GOARCH: X86, GOOS: WINDOWS, CGO_ENABLED: "0"},
-		map[string]string{GOARCH: X86_64, GOOS: WINDOWS, CGO_ENABLED: "0"},
+		{GOARCH: ARM64, GOOS: DARWIN, CGO_ENABLED: "0"},
+		{GOARCH: X86_64, GOOS: DARWIN, CGO_ENABLED: "0"},
+		{GOARCH: X86, GOOS: LINUX, CGO_ENABLED: "0"},
+		{GOARCH: X86_64, GOOS: LINUX, CGO_ENABLED: "0"},
+		{GOARCH: ARM64, GOOS: LINUX, CGO_ENABLED: "0"},
+		{GOARCH: X86, GOOS: WINDOWS, CGO_ENABLED: "0"},
+		{GOARCH: X86_64, GOOS: WINDOWS, CGO_ENABLED: "0"},
 	}
 )
 
@@ -350,10 +352,10 @@ func getUserHome() string {
 
 func getArch() string {
 	arch := getGOARCH()
-	if arch == X86 {
-		return "x86"
+	if arch == X86_64 {
+		return "x86_64"
 	}
-	return "x86_64"
+	return arch
 }
 
 func getGOARCH() string {

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "json-report",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "name": "JSON Report",
     "description": "JSON reporting plugin",
     "install": {


### PR DESCRIPTION
I recognized that arm64 support is missing for json report plugin.

I used these PR's as reference:
https://github.com/getgauge/gauge-java/pull/662
https://github.com/getgauge/gauge-java/pull/673