### PR TITLE
Add timestamp in ISO-8601 format to JSON report output

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -34,6 +34,7 @@ type item interface {
 type suiteResult struct {
 	ProjectName             string       `json:"projectName"`
 	Timestamp               string       `json:"timestamp"`
+	TimestampISO            string       `json:"timestampISO"`
 	SuccessRate             int          `json:"successRate"`
 	Environment             string       `json:"environment"`
 	Tags                    string       `json:"tags"`
@@ -56,6 +57,7 @@ type spec struct {
 	SpecHeading            string       `json:"specHeading"`
 	FileName               string       `json:"fileName"`
 	Tags                   []string     `json:"tags"`
+	TimestampISO           string       `json:"timestampISO"`
 	ExecutionTime          int64        `json:"executionTime"`
 	ExecutionStatus        status       `json:"executionStatus"`
 	Scenarios              []scenario   `json:"scenarios"`
@@ -162,6 +164,7 @@ func toSuiteResult(psr *gauge_messages.ProtoSuiteResult) suiteResult {
 		AfterSuiteHookMessages:  make([]string, 0),
 		SuccessRate:             int(psr.GetSuccessRate()),
 		Timestamp:               psr.GetTimestamp(),
+		TimestampISO:            psr.GetTimestampISO(),
 		ExecutionStatus:         pass,
 	}
 	if psr.GetPreHookMessages() != nil {
@@ -193,6 +196,7 @@ func toSpec(psr *gauge_messages.ProtoSpecResult) spec {
 		FailedScenarioCount:    int(psr.GetScenarioFailedCount()),
 		SkippedScenarioCount:   int(psr.GetScenarioSkippedCount()),
 		PassedScenarioCount:    int(psr.GetScenarioCount() - psr.GetScenarioFailedCount() - psr.GetScenarioSkippedCount()),
+		TimestampISO:           psr.GetTimestampISO(),
 		ExecutionTime:          psr.GetExecutionTime(),
 		ExecutionStatus:        getStatus(psr.GetFailed(), psr.GetSkipped()),
 		BeforeSpecHookFailure:  toSpecHookFailure(psr.GetProtoSpec().GetPreHookFailures()),

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/getgauge-contrib/json-report
 
-go 1.24
+go 1.24.5
+
+toolchain go1.24.6
 
 require (
 	github.com/getgauge/common v0.0.0-20250512071011-6a075badb588
-	github.com/getgauge/gauge-proto/go/gauge_messages v0.0.0-20250701084704-a1ce52e639cd
+	github.com/getgauge/gauge-proto/go/gauge_messages v0.0.0-20250807074548-a830d747c72b
 	github.com/xeipuuv/gojsonschema v1.2.0
 	google.golang.org/grpc v1.74.2
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/getgauge/common v0.0.0-20250512071011-6a075badb588 h1:2w5xN48+MY+CUtn
 github.com/getgauge/common v0.0.0-20250512071011-6a075badb588/go.mod h1:j4ycvkEuUDSM1pYN2HAwjHtT70ErW3gB/tFKIP8znfE=
 github.com/getgauge/gauge-proto/go/gauge_messages v0.0.0-20250701084704-a1ce52e639cd h1:6vcBYHcGt1Nw3Acblub5FmUyNt9E5GlM1us2n6/Xfv0=
 github.com/getgauge/gauge-proto/go/gauge_messages v0.0.0-20250701084704-a1ce52e639cd/go.mod h1:OMCZ/9zoRvl5mS1xJUgvFBM5MwbulLiHVxZ+Exls/f8=
+github.com/getgauge/gauge-proto/go/gauge_messages v0.0.0-20250807074548-a830d747c72b h1:G9JXBz2oJeFiiTvZc6NSN3IJP5ML5rW7cKzeU7Ly0mw=
+github.com/getgauge/gauge-proto/go/gauge_messages v0.0.0-20250807074548-a830d747c72b/go.mod h1:5HXYsvuXOleQccz+zWMbu6QKQcmEJlwzlBTediyhWzQ=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "json-report",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "name": "JSON Report",
     "description": "JSON reporting plugin",
     "install": {

--- a/schema.json
+++ b/schema.json
@@ -11,6 +11,10 @@
             "description": "Timestamp of execution",
             "type": "string"
         },
+        "timestampISO": {
+            "description": "Timestamp of execution in ISO-8601 format",
+            "type": "string"
+        },
         "successRate": {
             "description": "Success rate of execution",
             "type": "integer"


### PR DESCRIPTION
<img width="680" height="210" alt="image" src="https://github.com/user-attachments/assets/e73348f2-0d3b-4b27-823c-c12837795ea4" />


Related to: https://github.com/getgauge/gauge/pull/2764