### PR TITLE
chore: bump version from 0.5.5 to 0.5.6

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "json-report",
-    "version": "0.5.5",
+    "version": "0.5.6",
     "name": "JSON Report",
     "description": "JSON reporting plugin",
     "install": {


### PR DESCRIPTION
bumping version to use the latest go version