### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "json-report",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "name": "JSON Report",
     "description": "JSON reporting plugin",
     "install": {


### PR DESCRIPTION
Update plugin version from 1.0.1 to 1.0.2 to build the packages with 1.26.4 go version.

```
CVE-2026-42507 	 medium 	 net/textproto 		 1.26.3 		 fixed in 1.25.11, 1.26.4
CVE-2026-27145 	 high 	 crypto/x509 		 1.26.3 		 fixed in 1.25.11, 1.26.4
```