### PR TITLE
Add scenarioTableRowIndex to json-report

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -86,6 +86,7 @@ type scenario struct {
 	AfterScenarioHookMessages  []string     `json:"afterScenarioHookMessages"`
 	SkipErrors                 []string     `json:"skipErrors"`
 	TableRowIndex              int          `json:"tableRowIndex"`
+	ScenarioTableRowIndex      int          `json:"scenarioTableRowIndex"`
 	RetriesCount               int64        `json:"retriesCount"`
 }
 
@@ -218,9 +219,17 @@ func toSpec(psr *gauge_messages.ProtoSpecResult) spec {
 	for _, item := range psr.GetProtoSpec().GetItems() {
 		switch item.GetItemType() {
 		case gauge_messages.ProtoItem_Scenario:
-			spec.Scenarios = append(spec.Scenarios, toScenario(item.GetScenario(), -1))
+			spec.Scenarios = append(spec.Scenarios, toScenario(item.GetScenario(), -1, -1))
 		case gauge_messages.ProtoItem_TableDrivenScenario:
-			spec.Scenarios = append(spec.Scenarios, toScenario(item.GetTableDrivenScenario().GetScenario(), int(item.GetTableDrivenScenario().GetTableRowIndex())))
+			tds := item.GetTableDrivenScenario()
+			spec.Scenarios = append(
+				spec.Scenarios,
+				toScenario(
+					tds.GetScenario(),
+					int(tds.GetTableRowIndex()),
+					int(tds.GetScenarioTableRowIndex()),
+				),
+			)
 		case gauge_messages.ProtoItem_Table:
 			spec.Datatable = toTable(item.GetTable())
 		}
@@ -228,7 +237,7 @@ func toSpec(psr *gauge_messages.ProtoSpecResult) spec {
 	return spec
 }
 
-func toScenario(protoSce *gauge_messages.ProtoScenario, tableRowIndex int) scenario {
+func toScenario(protoSce *gauge_messages.ProtoScenario, tableRowIndex int, scenarioTableRowIndex int) scenario {
 	sce := scenario{
 		Heading:                    protoSce.GetScenarioHeading(),
 		ExecutionTime:              protoSce.GetExecutionTime(),
@@ -242,6 +251,7 @@ func toScenario(protoSce *gauge_messages.ProtoScenario, tableRowIndex int) scena
 		AfterScenarioHookFailure:   toHookFailure(protoSce.GetPostHookFailure()),
 		AfterScenarioHookMessages:  make([]string, 0),
 		TableRowIndex:              tableRowIndex,
+		ScenarioTableRowIndex:      scenarioTableRowIndex,
 		SkipErrors:                 make([]string, 0),
 		RetriesCount:               protoSce.GetRetriesCount(),
 	}

--- a/generate_test.go
+++ b/generate_test.go
@@ -34,7 +34,8 @@ func TestToScenario_SetsRetriesCount(t *testing.T) {
 	}
 
 	tableRowIndex := 0
-	sc := toScenario(protoSce, tableRowIndex)
+	scenarioTableRowIndex := -1
+	sc := toScenario(protoSce, tableRowIndex, scenarioTableRowIndex)
 
 	if sc.RetriesCount != expectedRetries {
 		t.Errorf("Expected RetriesCount to be %d, but got %d", expectedRetries, sc.RetriesCount)

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "json-report",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "name": "JSON Report",
     "description": "JSON reporting plugin",
     "install": {


### PR DESCRIPTION
In order to determine which scenario belongs to which scenario table, I need to know the scenario table row in combination with the (optional) test spec table row. This PR adds the given information of the proto message `ProtoTableDrivenScenario`.

By default this value is `-1`. In case the scenario is using a table (spec and/or scenario table), this value is set to 0...N.

Locally, I have installed this version and it works fine :) I can see the new property in the correct place with correct numbers.