### PR TITLE
Fix wrong values of tableRowIndex provided by generated proto functions

### DIFF
--- a/_testdata/sample.json
+++ b/_testdata/sample.json
@@ -91,8 +91,10 @@
           "afterScenarioHookFailure": null,
           "afterScenarioHookMessages": [],
           "skipErrors": [],
+          "isSpecTableDriven": false,
           "tableRowIndex": -1,
           "retriesCount": 0,
+          "isScenarioTableDriven": false,
           "scenarioTableRowIndex": -1
         },
         {
@@ -238,8 +240,10 @@
           "afterScenarioHookFailure": null,
           "afterScenarioHookMessages": [],
           "skipErrors": [],
+          "isSpecTableDriven": false,
           "tableRowIndex": -1,
           "retriesCount": 0,
+          "isScenarioTableDriven": false,
           "scenarioTableRowIndex": -1
         }
       ],

--- a/generate.go
+++ b/generate.go
@@ -242,6 +242,16 @@ func toSpec(psr *gauge_messages.ProtoSpecResult) spec {
 }
 
 func toScenario(protoSce *gauge_messages.ProtoScenario, tableRowIndex int, scenarioTableRowIndex int, isSpecTableDriven bool, isScenarioTableDriven bool) scenario {
+	if !isSpecTableDriven {
+		// Default must not be 0 but -1 if spec data table is not used
+		// Generated function is returning 0 though!
+		tableRowIndex = -1
+	}
+	if !isScenarioTableDriven {
+		// Default must not be 0 but -1 if scenario data table is not used
+		// Generated function is returning 0 though!
+		scenarioTableRowIndex = -1
+	}
 	sce := scenario{
 		Heading:                    protoSce.GetScenarioHeading(),
 		ExecutionTime:              protoSce.GetExecutionTime(),

--- a/generate.go
+++ b/generate.go
@@ -85,7 +85,9 @@ type scenario struct {
 	AfterScenarioHookFailure   *hookFailure `json:"afterScenarioHookFailure"`
 	AfterScenarioHookMessages  []string     `json:"afterScenarioHookMessages"`
 	SkipErrors                 []string     `json:"skipErrors"`
+	IsSpecTableDriven          bool         `json:"isSpecTableDriven"`
 	TableRowIndex              int          `json:"tableRowIndex"`
+	IsScenarioTableDriven      bool         `json:"isScenarioTableDriven"`
 	ScenarioTableRowIndex      int          `json:"scenarioTableRowIndex"`
 	RetriesCount               int64        `json:"retriesCount"`
 }
@@ -219,7 +221,7 @@ func toSpec(psr *gauge_messages.ProtoSpecResult) spec {
 	for _, item := range psr.GetProtoSpec().GetItems() {
 		switch item.GetItemType() {
 		case gauge_messages.ProtoItem_Scenario:
-			spec.Scenarios = append(spec.Scenarios, toScenario(item.GetScenario(), -1, -1))
+			spec.Scenarios = append(spec.Scenarios, toScenario(item.GetScenario(), -1, -1, false, false))
 		case gauge_messages.ProtoItem_TableDrivenScenario:
 			tds := item.GetTableDrivenScenario()
 			spec.Scenarios = append(
@@ -228,6 +230,8 @@ func toSpec(psr *gauge_messages.ProtoSpecResult) spec {
 					tds.GetScenario(),
 					int(tds.GetTableRowIndex()),
 					int(tds.GetScenarioTableRowIndex()),
+					tds.GetIsSpecTableDriven(),
+					tds.GetIsScenarioTableDriven(),
 				),
 			)
 		case gauge_messages.ProtoItem_Table:
@@ -237,7 +241,7 @@ func toSpec(psr *gauge_messages.ProtoSpecResult) spec {
 	return spec
 }
 
-func toScenario(protoSce *gauge_messages.ProtoScenario, tableRowIndex int, scenarioTableRowIndex int) scenario {
+func toScenario(protoSce *gauge_messages.ProtoScenario, tableRowIndex int, scenarioTableRowIndex int, isSpecTableDriven bool, isScenarioTableDriven bool) scenario {
 	sce := scenario{
 		Heading:                    protoSce.GetScenarioHeading(),
 		ExecutionTime:              protoSce.GetExecutionTime(),
@@ -250,7 +254,9 @@ func toScenario(protoSce *gauge_messages.ProtoScenario, tableRowIndex int, scena
 		BeforeScenarioHookMessages: make([]string, 0),
 		AfterScenarioHookFailure:   toHookFailure(protoSce.GetPostHookFailure()),
 		AfterScenarioHookMessages:  make([]string, 0),
+		IsSpecTableDriven:          isSpecTableDriven,
 		TableRowIndex:              tableRowIndex,
+		IsScenarioTableDriven:      isScenarioTableDriven,
 		ScenarioTableRowIndex:      scenarioTableRowIndex,
 		SkipErrors:                 make([]string, 0),
 		RetriesCount:               protoSce.GetRetriesCount(),

--- a/generate_test.go
+++ b/generate_test.go
@@ -35,7 +35,7 @@ func TestToScenario_SetsRetriesCount(t *testing.T) {
 
 	tableRowIndex := 0
 	scenarioTableRowIndex := -1
-	sc := toScenario(protoSce, tableRowIndex, scenarioTableRowIndex)
+	sc := toScenario(protoSce, tableRowIndex, scenarioTableRowIndex, false, false)
 
 	if sc.RetriesCount != expectedRetries {
 		t.Errorf("Expected RetriesCount to be %d, but got %d", expectedRetries, sc.RetriesCount)

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "json-report",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "JSON Report",
     "description": "JSON reporting plugin",
     "install": {

--- a/schema.json
+++ b/schema.json
@@ -216,9 +216,17 @@
                                     "type": "string"
                                 }
                             },
+                            "isSpecTableDriven": {
+                                "description": "True, if scenario is driven by a specification data table",
+                                "type": "boolean"
+                            },
                             "tableRowIndex": {
                                 "description": "Table row index, if its a table driven execution",
                                 "type": "integer"
+                            },
+                            "isScenarioTableDriven": {
+                                "description": "True, if scenario is driven by a scenario data table",
+                                "type": "boolean"
                             },
                             "scenarioTableRowIndex": {
                                 "description": "Scenario table row index, if its a table driven execution within a scenario",


### PR DESCRIPTION
While using the newest release of the json-report, I realized that there is still a bug. For some scenarios, the values "tableRowIndex" and "scenarioTableRowIndex" were set to 0 even though they did not access any table at all.

```
func (x *ProtoTableDrivenScenario) GetTableRowIndex() int32 {
	if x != nil {
		return x.TableRowIndex
	}
	return 0
}

func (x *ProtoTableDrivenScenario) GetScenarioTableRowIndex() int32 {
	if x != nil {
		return x.ScenarioTableRowIndex
	}
	return 0
}
```

These functions are generated with protoc based on the protobuf messages. The issue is, that proto3 does not allow to define default values - in this case we would require `-1` instead of 0.

To overcome this inconsistency I am adding the boolean values `isSpecTableDriven` and `isScenarioTableDriven` to determine if the values are correct and if not, I am actively changing them to -1.

I tested the changes locally with my repo: https://github.com/sschulz92/gauge-spec-table-scenario-bug-reproducer

The current json-report looks like this:

[result.json](https://github.com/user-attachments/files/31018050/result.json)

You can perfectly see, that the int values are set to -1 instead of 0 in case no data table is used (neither spec nor scenario table).
